### PR TITLE
Add tests to compare Objectness filters

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,8 +11,8 @@ itk_add_test(NAME itkObjectnessMeasureImageFilterTest1
   COMMAND ${itk-module}TestDriver
     --compareIntensityTolerance .001
     --compare
-      DATA{Baseline/ObjectnessMeasureImageFilterTest1.nii}
       ${ITK_TEST_OUTPUT_DIR}/ObjectnessMeasureImageFilterTestOutput1.nii
+      DATA{Baseline/ObjectnessMeasureImageFilterTest1.nii}
     itkObjectnessMeasureImageFilterTest
       DATA{Input/DSA.png}
       ${ITK_TEST_OUTPUT_DIR}/ObjectnessMeasureImageFilterTestOutput1.nii
@@ -23,13 +23,36 @@ itk_add_test(NAME itkObjectnessMeasureImageFilterTest2
   COMMAND ${itk-module}TestDriver
     --compareIntensityTolerance .001
     --compare
-      DATA{Baseline/ObjectnessMeasureImageFilterTest2.nii}
       ${ITK_TEST_OUTPUT_DIR}/ObjectnessMeasureImageFilterTestOutput2.nii
+      DATA{Baseline/ObjectnessMeasureImageFilterTest2.nii}
     itkObjectnessMeasureImageFilterTest
       DATA{Input/DSA.png}
       ${ITK_TEST_OUTPUT_DIR}/ObjectnessMeasureImageFilterTestOutput2.nii
       0 0
     )
+
+itk_add_test(NAME itkObjectnessMeasureImageFilterTest_compatibility1
+      COMMAND ${itk-module}TestDriver
+  --compareNumberOfPixelsTolerance 7000
+  --compareIntensityTolerance .01
+  --compare
+      ${ITK_TEST_OUTPUT_DIR}/itkObjectnessMeasureImageFilterTest_compatibility1.mha
+      DATA{${ITK_DATA_ROOT}/Baseline/Filtering/itkHessianToObjectnessMeasureImageFilterTest.mha}
+  itkObjectnessMeasureImageFilterTest
+    DATA{${ITK_DATA_ROOT}/Input/DSA.png}
+    ${ITK_TEST_OUTPUT_DIR}/itkObjectnessMeasureImageFilterTest_compatibility1.mha
+    1 0)
+itk_add_test(NAME itkObjectnessMeasureImageFilterTest_compatibility2
+      COMMAND ${itk-module}TestDriver
+  --compareNumberOfPixelsTolerance 7000
+  --compareIntensityTolerance .01
+  --compare
+    ${ITK_TEST_OUTPUT_DIR}/itkObjectnessMeasureImageFilterTest_compatibility2.mha
+    DATA{${ITK_DATA_ROOT}/Baseline/Filtering/itkHessianToObjectnessMeasureImageFilterTest2.mha}
+  itkObjectnessMeasureImageFilterTest
+    DATA{${ITK_DATA_ROOT}/Input/DSA.png}
+    ${ITK_TEST_OUTPUT_DIR}/itkObjectnessMeasureImageFilterTest_compatibility2.mha
+    0 0)
 
 add_test(NAME itkHessianImageFilterTest
       COMMAND ${itk-module}TestDriver itkHessianImageFilterTest )


### PR DESCRIPTION
These test reuse the test and baseline images from HessianToObjectness
filter. The over all image looks very similar but there are a number
of pixels (~7000) which are different. This is likely due to the
difference between the discrete derivative and utilizing the recursive
Gaussian derivatives.