### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkHessianImageFilter.h
+++ b/include/itkHessianImageFilter.h
@@ -47,6 +47,7 @@ class HessianImageFilter :
     public ImageToImageFilter< TInputImage, TOutputImage>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(HessianImageFilter);
 
   /** Standard type alias */
   using Self = HessianImageFilter;
@@ -88,10 +89,6 @@ protected:
   HessianImageFilter( void );
 
   void ThreadedGenerateData(const OutputImageRegionType& outputRegionForThread, ThreadIdType threadId) override;
-
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(HessianImageFilter);
-
 };
 
 } // end namespace itk

--- a/include/itkObjectnessMeasureImageFilter.h
+++ b/include/itkObjectnessMeasureImageFilter.h
@@ -34,6 +34,8 @@ class ObjectnessMeasureImageFilter
   : public ImageToImageFilter< TInputImage, TOutputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ObjectnessMeasureImageFilter);
+
   /** Standard class type alias. */
   using Self = ObjectnessMeasureImageFilter;
 
@@ -107,8 +109,6 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ObjectnessMeasureImageFilter);
-
   double       m_Alpha;
   double       m_Beta;
   double       m_Gamma;


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.