### PR TITLE
BUG: Use itk::SimpleFilterWatcher instead of itk::FilterWatcher.

### DIFF
--- a/test/itkObjectnessMeasureImageFilterTest.cxx
+++ b/test/itkObjectnessMeasureImageFilterTest.cxx
@@ -17,7 +17,7 @@
  *=========================================================================*/
 
 #include "itkTestingMacros.h"
-#include "itkFilterWatcher.h"
+#include "itkSimpleFilterWatcher.h"
 #include "itkObjectnessMeasureImageFilter.h"
 #include "itkSmoothingRecursiveGaussianImageFilter.h"
 #include "itkImageFileReader.h"
@@ -62,7 +62,7 @@ int itkObjectnessMeasureImageFilterTest(int argc, char *argv[])
   filter->SetObjectDimension(objectDimension);
   filter->SetScaleObjectnessMeasure(false);
 
-  FilterWatcher watcher(filter);
+  itk::SimpleFilterWatcher watcher(filter);
 
   using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();


### PR DESCRIPTION
Use `itk::SimpleFilterWatcher` instead of `itk::FilterWatcher`.

The `itk::FilterWatcher` class was removed in favour of
`itk::SimpleFilterWatcher` (and thus, its header file named
`itkFilterWatcher.h` was deleted) in this gerrit topic:
http://review.source.kitware.com/#/c/23415/

This bug was identified thanks to the following gerrit topic:
http://review.source.kitware.com/#/c/23428/