### PR TITLE
BUG: Fix test errors steming from the new multi-threading mechanism.

### DIFF
--- a/include/itkHessianImageFilter.h
+++ b/include/itkHessianImageFilter.h
@@ -88,7 +88,7 @@ protected:
 
   HessianImageFilter( void );
 
-  void ThreadedGenerateData(const OutputImageRegionType& outputRegionForThread, ThreadIdType threadId) override;
+  void DynamicThreadedGenerateData(const OutputImageRegionType& outputRegionForThread) override;
 };
 
 } // end namespace itk

--- a/include/itkHessianImageFilter.hxx
+++ b/include/itkHessianImageFilter.hxx
@@ -25,9 +25,6 @@
 #include "itkImageRegionIterator.h"
 #include "itkNeighborhoodAlgorithm.h"
 
-#include "itkProgressReporter.h"
-#include "itkProgressAccumulator.h"
-
 namespace itk
 {
 
@@ -39,6 +36,7 @@ template <typename TInputImage, typename TOutputImage >
 HessianImageFilter<TInputImage,TOutputImage>
 ::HessianImageFilter( void )
 {
+  this->DynamicMultiThreadingOn();
 }
 
 /**
@@ -103,11 +101,8 @@ HessianImageFilter< TInputImage, TOutputImage >
 template <typename TInputImage, typename TOutputImage >
 void
 HessianImageFilter<TInputImage,TOutputImage>
-::ThreadedGenerateData(const OutputImageRegionType& outputRegionForThread,
-                       ThreadIdType threadId)
+::DynamicThreadedGenerateData(const OutputImageRegionType& outputRegionForThread)
 {
-  ProgressReporter progress(this, threadId, outputRegionForThread.GetNumberOfPixels() );
-
   const TInputImage *input = this->GetInput();
 
   const unsigned int ImageDimension = TInputImage::ImageDimension;
@@ -183,7 +178,6 @@ HessianImageFilter<TInputImage,TOutputImage>
 
       ++oit;
       ++it;
-       progress.CompletedPixel();
       }
     }
 


### PR DESCRIPTION
Fix errors steming from the use of the new `itk::PoolMultiThreader`
class for multi-threading.

The errors stemmed when this gerrit topic got merged:
http://review.source.kitware.com/#/c/23175/

And were later related to the following gerrit-topic:
http://review.source.kitware.com/#/c/23434/

The solution adopted in this patch set was based on the proposal in:
http://review.source.kitware.com/#/c/23439/