### PR TITLE
ENH: Refactor enums into DICOMOrientation class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10.2)
 project(SimpleITKFilters)
 
-#set(SimpleITKFilters_LIBRARIES SimpleITKFilters)
+set(SimpleITKFilters_LIBRARIES SimpleITKFilters)
 
 if(NOT ITK_SOURCE_DIR)
   find_package(ITK REQUIRED)

--- a/include/itkDICOMOrientation.h
+++ b/include/itkDICOMOrientation.h
@@ -1,0 +1,251 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkDICOMOrientation_h
+#define itkDICOMOrientation_h
+
+#include "SimpleITKFiltersExport.h"
+#include "itkImageBase.h"
+#include <map>
+#include <string>
+
+namespace itk
+{
+
+/** \class DICOMOrientation
+ * \brief A supporting class for DICOMOrientImageFilter.
+ *
+ *  Defines enums to for patient orientation in a compatible way with DICOM.
+ *
+ *  Instances hold the patient orientation enum and allow conversion to and from enums, string and direction cosine
+ * matrices. Conversions from a direction cosine matrix is approximated with the orientation of the closes axes.
+ *
+ * \ingroup SimpleITKFilters
+ */
+class SimpleITKFilters_EXPORT DICOMOrientation
+{
+public:
+  constexpr static unsigned int Dimension = 3;
+  using DirectionType = typename ImageBase<Dimension>::DirectionType;
+  constexpr static unsigned int ImageDimension = Dimension;
+
+
+  enum class CoordinateEnum : uint8_t
+  {
+    UNKNOWN = 0,
+    Right = 2, // 0b0010
+    Left = 3,
+    Anterior = 4,  ///< front - 0b0100
+    Posterior = 5, ///< back
+    Inferior = 8,  ///< bottom - 0b1000
+    Superior = 9   ///< above
+  };
+
+private:
+  enum class CoordinateMajornessTermsEnum : uint8_t
+  {
+    PrimaryMinor = 0,
+    SecondaryMinor = 8,
+    TertiaryMinor = 16
+  };
+
+  constexpr static uint32_t
+  toOrientation(const CoordinateEnum primary, const CoordinateEnum secondary, const CoordinateEnum tertiary)
+  {
+    return (static_cast<uint32_t>(primary) << static_cast<uint8_t>(CoordinateMajornessTermsEnum::PrimaryMinor)) +
+           (static_cast<uint32_t>(secondary) << static_cast<uint8_t>(CoordinateMajornessTermsEnum::SecondaryMinor)) +
+           (static_cast<uint32_t>(tertiary) << static_cast<uint8_t>(CoordinateMajornessTermsEnum::TertiaryMinor));
+  }
+
+public:
+#if 0
+#  define ITK_ORIENTATIONENUM toOrientation
+#else
+
+#  define ITK_ORIENTATIONENUM(P, S, T)                                                                                 \
+    (static_cast<uint32_t>(P) << static_cast<uint8_t>(CoordinateMajornessTermsEnum::PrimaryMinor)) +                   \
+      (static_cast<uint32_t>(S) << static_cast<uint8_t>(CoordinateMajornessTermsEnum::SecondaryMinor)) +               \
+      (static_cast<uint32_t>(T) << static_cast<uint8_t>(CoordinateMajornessTermsEnum::TertiaryMinor))
+
+#endif
+
+  enum class OrientationEnum : uint32_t
+
+  {
+    INVALID = 0,
+    RIP = ITK_ORIENTATIONENUM(CoordinateEnum::Right, CoordinateEnum::Inferior, CoordinateEnum::Posterior),
+    LIP = ITK_ORIENTATIONENUM(CoordinateEnum::Left, CoordinateEnum::Inferior, CoordinateEnum::Posterior),
+    RSP = ITK_ORIENTATIONENUM(CoordinateEnum::Right, CoordinateEnum::Superior, CoordinateEnum::Posterior),
+    LSP = ITK_ORIENTATIONENUM(CoordinateEnum::Left, CoordinateEnum::Superior, CoordinateEnum::Posterior),
+    RIA = ITK_ORIENTATIONENUM(CoordinateEnum::Right, CoordinateEnum::Inferior, CoordinateEnum::Anterior),
+    LIA = ITK_ORIENTATIONENUM(CoordinateEnum::Left, CoordinateEnum::Inferior, CoordinateEnum::Anterior),
+    RSA = ITK_ORIENTATIONENUM(CoordinateEnum::Right, CoordinateEnum::Superior, CoordinateEnum::Anterior),
+    LSA = ITK_ORIENTATIONENUM(CoordinateEnum::Left, CoordinateEnum::Superior, CoordinateEnum::Anterior),
+
+    IRP = ITK_ORIENTATIONENUM(CoordinateEnum::Inferior, CoordinateEnum::Right, CoordinateEnum::Posterior),
+    ILP = ITK_ORIENTATIONENUM(CoordinateEnum::Inferior, CoordinateEnum::Left, CoordinateEnum::Posterior),
+    SRP = ITK_ORIENTATIONENUM(CoordinateEnum::Superior, CoordinateEnum::Right, CoordinateEnum::Posterior),
+    SLP = ITK_ORIENTATIONENUM(CoordinateEnum::Superior, CoordinateEnum::Left, CoordinateEnum::Posterior),
+    IRA = ITK_ORIENTATIONENUM(CoordinateEnum::Inferior, CoordinateEnum::Right, CoordinateEnum::Anterior),
+    ILA = ITK_ORIENTATIONENUM(CoordinateEnum::Inferior, CoordinateEnum::Left, CoordinateEnum::Anterior),
+    SRA = ITK_ORIENTATIONENUM(CoordinateEnum::Superior, CoordinateEnum::Right, CoordinateEnum::Anterior),
+    SLA = ITK_ORIENTATIONENUM(CoordinateEnum::Superior, CoordinateEnum::Left, CoordinateEnum::Anterior),
+
+    RPI = ITK_ORIENTATIONENUM(CoordinateEnum::Right, CoordinateEnum::Posterior, CoordinateEnum::Inferior),
+    LPI = ITK_ORIENTATIONENUM(CoordinateEnum::Left, CoordinateEnum::Posterior, CoordinateEnum::Inferior),
+    RAI = ITK_ORIENTATIONENUM(CoordinateEnum::Right, CoordinateEnum::Anterior, CoordinateEnum::Inferior),
+    LAI = ITK_ORIENTATIONENUM(CoordinateEnum::Left, CoordinateEnum::Anterior, CoordinateEnum::Inferior),
+    RPS = ITK_ORIENTATIONENUM(CoordinateEnum::Right, CoordinateEnum::Posterior, CoordinateEnum::Superior),
+    LPS = ITK_ORIENTATIONENUM(CoordinateEnum::Left, CoordinateEnum::Posterior, CoordinateEnum::Superior),
+    RAS = ITK_ORIENTATIONENUM(CoordinateEnum::Right, CoordinateEnum::Anterior, CoordinateEnum::Superior),
+    LAS = ITK_ORIENTATIONENUM(CoordinateEnum::Left, CoordinateEnum::Anterior, CoordinateEnum::Superior),
+
+    PRI = ITK_ORIENTATIONENUM(CoordinateEnum::Posterior, CoordinateEnum::Right, CoordinateEnum::Inferior),
+    PLI = ITK_ORIENTATIONENUM(CoordinateEnum::Posterior, CoordinateEnum::Left, CoordinateEnum::Inferior),
+    ARI = ITK_ORIENTATIONENUM(CoordinateEnum::Anterior, CoordinateEnum::Right, CoordinateEnum::Inferior),
+    ALI = ITK_ORIENTATIONENUM(CoordinateEnum::Anterior, CoordinateEnum::Left, CoordinateEnum::Inferior),
+    PRS = ITK_ORIENTATIONENUM(CoordinateEnum::Posterior, CoordinateEnum::Right, CoordinateEnum::Superior),
+    PLS = ITK_ORIENTATIONENUM(CoordinateEnum::Posterior, CoordinateEnum::Left, CoordinateEnum::Superior),
+    ARS = ITK_ORIENTATIONENUM(CoordinateEnum::Anterior, CoordinateEnum::Right, CoordinateEnum::Superior),
+    ALS = ITK_ORIENTATIONENUM(CoordinateEnum::Anterior, CoordinateEnum::Left, CoordinateEnum::Superior),
+
+    IPR = ITK_ORIENTATIONENUM(CoordinateEnum::Inferior, CoordinateEnum::Posterior, CoordinateEnum::Right),
+    SPR = ITK_ORIENTATIONENUM(CoordinateEnum::Superior, CoordinateEnum::Posterior, CoordinateEnum::Right),
+    IAR = ITK_ORIENTATIONENUM(CoordinateEnum::Inferior, CoordinateEnum::Anterior, CoordinateEnum::Right),
+    SAR = ITK_ORIENTATIONENUM(CoordinateEnum::Superior, CoordinateEnum::Anterior, CoordinateEnum::Right),
+    IPL = ITK_ORIENTATIONENUM(CoordinateEnum::Inferior, CoordinateEnum::Posterior, CoordinateEnum::Left),
+    SPL = ITK_ORIENTATIONENUM(CoordinateEnum::Superior, CoordinateEnum::Posterior, CoordinateEnum::Left),
+    IAL = ITK_ORIENTATIONENUM(CoordinateEnum::Inferior, CoordinateEnum::Anterior, CoordinateEnum::Left),
+    SAL = ITK_ORIENTATIONENUM(CoordinateEnum::Superior, CoordinateEnum::Anterior, CoordinateEnum::Left),
+
+    PIR = ITK_ORIENTATIONENUM(CoordinateEnum::Posterior, CoordinateEnum::Inferior, CoordinateEnum::Right),
+    PSR = ITK_ORIENTATIONENUM(CoordinateEnum::Posterior, CoordinateEnum::Superior, CoordinateEnum::Right),
+    AIR = ITK_ORIENTATIONENUM(CoordinateEnum::Anterior, CoordinateEnum::Inferior, CoordinateEnum::Right),
+    ASR = ITK_ORIENTATIONENUM(CoordinateEnum::Anterior, CoordinateEnum::Superior, CoordinateEnum::Right),
+    PIL = ITK_ORIENTATIONENUM(CoordinateEnum::Posterior, CoordinateEnum::Inferior, CoordinateEnum::Left),
+    PSL = ITK_ORIENTATIONENUM(CoordinateEnum::Posterior, CoordinateEnum::Superior, CoordinateEnum::Left),
+    AIL = ITK_ORIENTATIONENUM(CoordinateEnum::Anterior, CoordinateEnum::Inferior, CoordinateEnum::Left),
+    ASL = ITK_ORIENTATIONENUM(CoordinateEnum::Anterior, CoordinateEnum::Superior, CoordinateEnum::Left)
+  };
+
+#undef ITK_ORIENTATIONENUM
+
+
+  DICOMOrientation(CoordinateEnum primary, CoordinateEnum secondary, CoordinateEnum tertiary);
+
+  DICOMOrientation(OrientationEnum orientation)
+    : m_Value(orientation)
+  {}
+
+  explicit DICOMOrientation(const DirectionType & d)
+    : m_Value(DirectionCosinesToOrientation(d))
+  {}
+
+  explicit DICOMOrientation(const std::string & str);
+
+  operator OrientationEnum() const { return m_Value; }
+
+  const std::string &
+  GetAsString() const;
+
+  DirectionType
+  GetAsDirection() const
+  {
+    return OrientationToDirectionCosines(m_Value);
+  }
+
+  OrientationEnum
+  GetAsOrientation() const
+  {
+    return m_Value;
+  }
+
+  CoordinateEnum
+  GetCoordinateTerm(CoordinateMajornessTermsEnum cmt) const;
+
+  CoordinateEnum
+  GetPrimaryTerm() const
+  {
+    return GetCoordinateTerm(CoordinateMajornessTermsEnum::PrimaryMinor);
+  }
+
+  CoordinateEnum
+  GetSecondaryTerm() const
+  {
+    return GetCoordinateTerm(CoordinateMajornessTermsEnum::SecondaryMinor);
+  }
+
+  CoordinateEnum
+  GetTertiaryTerm() const
+  {
+    return GetCoordinateTerm(CoordinateMajornessTermsEnum::TertiaryMinor);
+  }
+
+
+  static bool
+  SameOrientationAxes(CoordinateEnum a, CoordinateEnum b)
+  {
+    const unsigned int AxisField = 0xE; // b1110, make lowest bit
+    return (static_cast<uint8_t>(a) & AxisField) == (static_cast<uint8_t>(b) & AxisField);
+  }
+
+  /** \brief Return the closest orientation for a direction cosine matrix. */
+  static OrientationEnum
+  DirectionCosinesToOrientation(const DirectionType & dir);
+
+  /** \brief Return the direction cosine matrix for a orientation. */
+  static DirectionType OrientationToDirectionCosines(OrientationEnum);
+
+
+  friend SimpleITKFilters_EXPORT std::ostream &
+  operator<<(std::ostream & out, OrientationEnum value);
+
+
+private:
+  // Private methods to create the maps, these will only be called once.
+  static std::map<OrientationEnum, std::string>
+  CreateCodeToString();
+  static std::map<std::string, OrientationEnum>
+  CreateStringToCode();
+
+  /** \brief Return the global instance of the map from orientation enum to strings.
+   *
+   * The implementation uses a function static local variable so the global is created only if needed, only once.
+   */
+  static const std::map<OrientationEnum, std::string> &
+  GetCodeToString();
+
+  /** \brief Return the global instance of the map from string to orientation enum.
+   */
+  static const std::map<std::string, OrientationEnum> &
+  GetStringToCode();
+
+  OrientationEnum m_Value;
+};
+
+
+SimpleITKFilters_EXPORT std::ostream &
+                        operator<<(std::ostream & out, typename DICOMOrientation::OrientationEnum value);
+
+SimpleITKFilters_EXPORT std::ostream &
+                        operator<<(std::ostream & out, const DICOMOrientation & orientation);
+
+
+} // end namespace itk
+
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SimpleITKFilters_SRCS
+        itkDICOMOrientation.cxx
+        )
+
+itk_module_add_library(SimpleITKFilters ${SimpleITKFilters_SRCS})

--- a/src/itkDICOMOrientation.cxx
+++ b/src/itkDICOMOrientation.cxx
@@ -1,0 +1,252 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "itkDICOMOrientation.h"
+
+// Needed for itk::Function::Max3
+#include "itkSpatialOrientationAdapter.h"
+
+
+namespace itk
+{
+
+
+DICOMOrientation::DICOMOrientation(CoordinateEnum primary, CoordinateEnum secondary, CoordinateEnum tertiary)
+{
+if (SameOrientationAxes(primary, secondary) || SameOrientationAxes(primary, tertiary) ||
+SameOrientationAxes(secondary, tertiary))
+{
+m_Value = OrientationEnum::INVALID;
+}
+else{
+m_Value = static_cast<OrientationEnum>(toOrientation(primary, secondary, tertiary));
+}
+}
+
+DICOMOrientation::DICOMOrientation(const std::string & str)
+  : m_Value(OrientationEnum::INVALID)
+{
+  const std::map<std::string, typename DICOMOrientation::OrientationEnum> & stringToCode = GetStringToCode();
+  auto                                                                      iter = stringToCode.find(str);
+  if (iter != stringToCode.end())
+  {
+    m_Value = iter->second;
+  }
+}
+
+
+const std::string &
+DICOMOrientation::GetAsString() const
+{
+  auto iter = GetCodeToString().find(m_Value);
+  if (iter != GetCodeToString().end())
+  {
+    GetCodeToString().find(OrientationEnum::INVALID);
+  }
+  return iter->second;
+}
+
+
+DICOMOrientation::CoordinateEnum
+DICOMOrientation::GetCoordinateTerm(CoordinateMajornessTermsEnum cmt) const
+{
+  return static_cast<CoordinateEnum>(static_cast<uint32_t>(m_Value) >> static_cast<uint8_t>(cmt) & 0xff);
+}
+
+std::map<std::string, typename DICOMOrientation::OrientationEnum>
+DICOMOrientation::CreateStringToCode()
+{
+  std::map<std::string, OrientationEnum>         stringToCode;
+  const std::map<OrientationEnum, std::string> & codeToString = GetCodeToString();
+
+  for (const auto & kv : codeToString)
+  {
+    stringToCode[kv.second] = kv.first;
+  }
+  return stringToCode;
+}
+
+
+const std::map<typename DICOMOrientation::OrientationEnum, std::string> &
+DICOMOrientation::GetCodeToString()
+{
+  static const std::map<OrientationEnum, std::string> codeToString = CreateCodeToString();
+  return codeToString;
+}
+
+const std::map<std::string, DICOMOrientation::OrientationEnum> &
+DICOMOrientation::GetStringToCode()
+{
+  static const std::map<std::string, DICOMOrientation::OrientationEnum> stringToCode = CreateStringToCode();
+  return stringToCode;
+}
+
+
+std::map<typename DICOMOrientation::OrientationEnum, std::string>
+DICOMOrientation::CreateCodeToString()
+{
+  std::map<OrientationEnum, std::string> orientToString;
+  auto                                   helperAddCode = [&orientToString](std::string str, OrientationEnum code) {
+    orientToString[code] = std::move(str);
+  };
+
+  // Map between axis string labels and SpatialOrientation
+  helperAddCode("RIP", OrientationEnum::RIP);
+  helperAddCode("LIP", OrientationEnum::LIP);
+  helperAddCode("RSP", OrientationEnum::RSP);
+  helperAddCode("LSP", OrientationEnum::LSP);
+  helperAddCode("RIA", OrientationEnum::RIA);
+  helperAddCode("LIA", OrientationEnum::LIA);
+  helperAddCode("RSA", OrientationEnum::RSA);
+  helperAddCode("LSA", OrientationEnum::LSA);
+  helperAddCode("IRP", OrientationEnum::IRP);
+  helperAddCode("ILP", OrientationEnum::ILP);
+  helperAddCode("SRP", OrientationEnum::SRP);
+  helperAddCode("SLP", OrientationEnum::SLP);
+  helperAddCode("IRA", OrientationEnum::IRA);
+  helperAddCode("ILA", OrientationEnum::ILA);
+  helperAddCode("SRA", OrientationEnum::SRA);
+  helperAddCode("SLA", OrientationEnum::SLA);
+  helperAddCode("RPI", OrientationEnum::RPI);
+  helperAddCode("LPI", OrientationEnum::LPI);
+  helperAddCode("RAI", OrientationEnum::RAI);
+  helperAddCode("LAI", OrientationEnum::LAI);
+  helperAddCode("RPS", OrientationEnum::RPS);
+  helperAddCode("LPS", OrientationEnum::LPS);
+  helperAddCode("RAS", OrientationEnum::RAS);
+  helperAddCode("LAS", OrientationEnum::LAS);
+  helperAddCode("PRI", OrientationEnum::PRI);
+  helperAddCode("PLI", OrientationEnum::PLI);
+  helperAddCode("ARI", OrientationEnum::ARI);
+  helperAddCode("ALI", OrientationEnum::ALI);
+  helperAddCode("PRS", OrientationEnum::PRS);
+  helperAddCode("PLS", OrientationEnum::PLS);
+  helperAddCode("ARS", OrientationEnum::ARS);
+  helperAddCode("ALS", OrientationEnum::ALS);
+  helperAddCode("IPR", OrientationEnum::IPR);
+  helperAddCode("SPR", OrientationEnum::SPR);
+  helperAddCode("IAR", OrientationEnum::IAR);
+  helperAddCode("SAR", OrientationEnum::SAR);
+  helperAddCode("IPL", OrientationEnum::IPL);
+  helperAddCode("SPL", OrientationEnum::SPL);
+  helperAddCode("IAL", OrientationEnum::IAL);
+  helperAddCode("SAL", OrientationEnum::SAL);
+  helperAddCode("PIR", OrientationEnum::PIR);
+  helperAddCode("PSR", OrientationEnum::PSR);
+  helperAddCode("AIR", OrientationEnum::AIR);
+  helperAddCode("ASR", OrientationEnum::ASR);
+  helperAddCode("PIL", OrientationEnum::PIL);
+  helperAddCode("PSL", OrientationEnum::PSL);
+  helperAddCode("AIL", OrientationEnum::AIL);
+  helperAddCode("ASL", OrientationEnum::ASL);
+  helperAddCode("INVALID", OrientationEnum::INVALID);
+
+  return orientToString;
+}
+
+
+typename DICOMOrientation::OrientationEnum
+DICOMOrientation::DirectionCosinesToOrientation(const DirectionType & dir)
+{
+  // NOTE: This method was based off of itk::SpatialObjectAdaptor::FromDirectionCosines
+  // but it is DIFFERENT in the meaning of direction in terms of sign-ness.
+  CoordinateEnum terms[3] = { CoordinateEnum::UNKNOWN, CoordinateEnum::UNKNOWN, CoordinateEnum::UNKNOWN };
+
+  for (unsigned i = 0; i < 3; i++)
+  {
+
+    const unsigned dominant_axis = Function::Max3(dir[0][i], dir[1][i], dir[2][i]);
+
+    const int dominate_sgn = Math::sgn(dir[dominant_axis][i]);
+
+    switch (dominant_axis)
+    {
+      case 0: {
+        // When the dominate axis sign is positive, assign the coordinate for the direction we are increasing towards.
+        // ITK is in LPS, so that is the positive direction
+        terms[i] = (dominate_sgn == 1) ? CoordinateEnum::Left : CoordinateEnum::Right;
+        break;
+      }
+      case 1: {
+        terms[i] = (dominate_sgn == 1) ? CoordinateEnum::Posterior : CoordinateEnum::Anterior;
+        break;
+      }
+      case 2: {
+        terms[i] = (dominate_sgn == 1) ? CoordinateEnum::Superior : CoordinateEnum::Inferior;
+        break;
+      }
+      default:
+        itkGenericExceptionMacro("Unexpected Axis")
+    }
+  }
+
+  return static_cast<OrientationEnum>(toOrientation(terms[0], terms[1], terms[2]));
+}
+
+
+typename DICOMOrientation::DirectionType
+DICOMOrientation::OrientationToDirectionCosines(OrientationEnum orientationEnum)
+{
+  const DICOMOrientation o(orientationEnum);
+
+  CoordinateEnum terms[Dimension] = { o.GetPrimaryTerm(),
+                                      o.GetSecondaryTerm(),
+                                      o.GetTertiaryTerm() };
+  DirectionType direction;
+  direction.Fill(0.0);
+
+  for (unsigned int i = 0; i < Dimension; ++i)
+  {
+    const int sign = (static_cast<uint8_t>(terms[i]) & 0x1) ? 1 : -1;
+
+    switch (terms[i])
+    {
+      case CoordinateEnum::Left:
+      case CoordinateEnum::Right:
+        direction[0][i] = 1 * sign;
+        break;
+      case CoordinateEnum::Anterior:
+      case CoordinateEnum::Posterior:
+        direction[1][i] = 1 * sign;
+        break;
+      case CoordinateEnum::Inferior:
+      case CoordinateEnum::Superior:
+        direction[2][i] = 1 * sign;
+        break;
+      default:
+        break;
+    }
+  }
+  return direction;
+}
+
+std::ostream &
+operator<<(std::ostream & out, typename DICOMOrientation::OrientationEnum value)
+{
+  auto iter = DICOMOrientation::GetCodeToString().find(value);
+  assert(iter != DICOMOrientation::GetCodeToString().end());
+  return (out << iter->second);
+}
+
+
+std::ostream &
+operator<<(std::ostream & out, const DICOMOrientation &orientation)
+{
+  return (out << orientation.GetAsString());
+}
+
+} // namespace itk


### PR DESCRIPTION
Creates new DICOMOrientation class to hold the enumeration declaration
and hold the value. Additionally, the class contains conversions
between the OrientationEnum, direction cosine matrix, and string
representation. Additionally, bit-wise manipulation of the enum
encoding was refactored as class members. These changes enable unit
tests of many of these operations, to better verify correct behavior
of smaller components.