### PR TITLE
Initialized arrays in constructor, address valgrind defect

### DIFF
--- a/include/itkDICOMOrientImageFilter.h
+++ b/include/itkDICOMOrientImageFilter.h
@@ -180,8 +180,8 @@ private:
   DICOMOrientation m_InputCoordinateOrientation{ OrientationEnum::INVALID };
   DICOMOrientation m_DesiredCoordinateOrientation{ OrientationEnum::LPS };
 
-  PermuteOrderArrayType m_PermuteOrder{ { 0, 1, 2 } };
-  FlipAxesArrayType     m_FlipAxes{ { false, false, false } };
+  PermuteOrderArrayType m_PermuteOrder;
+  FlipAxesArrayType     m_FlipAxes;
 
 }; // end of class
 

--- a/include/itkDICOMOrientImageFilter.hxx
+++ b/include/itkDICOMOrientImageFilter.hxx
@@ -29,8 +29,8 @@ namespace itk
 
 template <typename TInputImage>
 DICOMOrientImageFilter<TInputImage>::DICOMOrientImageFilter()
+  : m_FlipAxes{false}
 {
-
   for (unsigned int dimension = 0; dimension < ImageDimension; ++dimension)
   {
     this->m_PermuteOrder[dimension] = dimension;


### PR DESCRIPTION
The FixedArrays were being incorrectly constructed with references to
C style array initializers.