### PR TITLE
BUG: Safely return INVALID in GetAsString

### DIFF
--- a/src/itkDICOMOrientation.cxx
+++ b/src/itkDICOMOrientation.cxx
@@ -54,12 +54,14 @@ DICOMOrientation::DICOMOrientation(std::string str)
 const std::string &
 DICOMOrientation::GetAsString() const
 {
-  auto iter = GetCodeToString().find(m_Value);
-  if (iter != GetCodeToString().end())
-  {
-    GetCodeToString().find(OrientationEnum::INVALID);
-  }
-  return iter->second;
+  const auto & codeToString = GetCodeToString();
+  auto iter = codeToString.find(m_Value);
+  if (iter != codeToString.end())
+    {
+    return iter->second;
+    }
+  assert( codeToString.find(OrientationEnum::INVALID) != codeToString.end());
+  return codeToString.find(OrientationEnum::INVALID)->second;
 }
 
 

--- a/test/itkDICOMOrientImageFilterGTest.cxx
+++ b/test/itkDICOMOrientImageFilterGTest.cxx
@@ -385,6 +385,13 @@ TEST(DICOMOrientation, ConstructionAndValues)
   EXPECT_EQ(OE::PIR, do2.GetAsOrientation());
 
   EXPECT_EQ(d, do2.GetAsDirection());
+
+  DICOMOrientation do3("something invalid");
+  EXPECT_EQ("INVALID", do3.GetAsString());
+  EXPECT_EQ(CE::UNKNOWN, do3.GetPrimaryTerm());
+  EXPECT_EQ(CE::UNKNOWN, do3.GetSecondaryTerm());
+  EXPECT_EQ(CE::UNKNOWN, do3.GetTertiaryTerm());
+  EXPECT_EQ(OE::INVALID, do3.GetAsOrientation());
 }
 
 


### PR DESCRIPTION
Address warning related to unused value of the map::find operations.

Add more tests related to INVALID DICOMOrientation value.